### PR TITLE
Added hide terminal on child exit

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -175,6 +175,7 @@ static void term_eof_or_child_exited(VteTerminal *term, gpointer user_data)
         /* else close the tab */
         mainwindow_close_tab(GTK_WIDGET(term));
     }
+    gtk_widget_hide(GTK_WIDGET(mainwindow));
 }
 
 static void term_app_request(VteTerminal *term, gpointer user_data)


### PR DESCRIPTION
I liked the behaviour in 0.14 where I could exit a child (ie: hit Ctrl+D to logout of an stjerm) and the terminal would hide, but would re-create a fresh shell which would sit hidden waiting for me to use it again in the future. This commit adds that behaviour back.
