### PR TITLE
correct manpage case of fixedx and fixedy

### DIFF
--- a/doc/stjerm.8
+++ b/doc/stjerm.8
@@ -107,10 +107,10 @@ Whether to scroll the terminal on output. Default: \fItrue\fR.
 Specify color X of the terminals color palette. You may specify no palette, or a complete one with 16 total colors.
 For this you have to use \-c0, \-c1, ..., \-c15 or the equivalent color0, color1,... color15.
 .TP
-.B "fixedX, \-fX"
+.B "fixedx, \-fX"
 Overrides the calculated horizontal position of the window. Specifies the location of the left of the window.
 .TP
-.B "fixedY, \-fY"
+.B "fixedy, \-fY"
 Overrides the calculated vertical position of the window. Specifies the location of the top of the window.
 .TP
 .B "allowreorder, \-ar"


### PR DESCRIPTION
The manpage lists options fixedX and fixedX bu they are actually fixedx
and fixedy. This patch corrects the manpage with the correct case.

Signed-off-by: Jamie Bainbridge <jamie.bainbridge@gmail.com>